### PR TITLE
Update dynamodb-streams-kinesis-adapter and aws sdk versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dynamodb-local.port>8000</dynamodb-local.port>
         <dynamodb-local.endpoint>http://localhost:${dynamodb-local.port}</dynamodb-local.endpoint>
-        <aws.java.sdk.version>[1.10.5.1, 2.0.0)</aws.java.sdk.version>
+        <aws.java.sdk.version>[1.11.89, 2.0.0)</aws.java.sdk.version>
         <slf4j.version>1.7.5</slf4j.version>
         <aws.dynamodblocal.version>1.11.0.1</aws.dynamodblocal.version>
-        <amazon.kinesis-client-library.version>1.5.0</amazon.kinesis-client-library.version>
-        <amazon.kinesis-connectors.version>1.2.0</amazon.kinesis-connectors.version>
-        <dynamodb-streams-kinesis-adapter.version>1.0.0</dynamodb-streams-kinesis-adapter.version>
+        <amazon.kinesis-client-library.version>1.7.3</amazon.kinesis-client-library.version>
+        <amazon.kinesis-connectors.version>1.3.0</amazon.kinesis-connectors.version>
+        <dynamodb-streams-kinesis-adapter.version>1.1.1</dynamodb-streams-kinesis-adapter.version>
         <maven.assembly.version>2.5.3</maven.assembly.version>
         <maven.compiler.version>3.3</maven.compiler.version>
         <maven.dependency.version>2.10</maven.dependency.version>


### PR DESCRIPTION
old dynamodb-streams-kinesis-adapter version causes maven to download many old aws sdk versions (1.10.x). There about 80 1.10.x versions.
if we switch to dynamodb-streams-kinesis-adapter 1.11.1 then maven will only download aws sdk 1.11.14 and newer.