### PR TITLE
Add explanation on how to run DynamoDBLocalFixture

### DIFF
--- a/src/test/java/com/amazonaws/services/dynamodbv2/DynamoDBLocalFixture.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/DynamoDBLocalFixture.java
@@ -26,6 +26,20 @@ import com.amazonaws.services.dynamodbv2.model.ListTablesResult;
  * @author Alexander Patrikalakis
  */
 public class DynamoDBLocalFixture {
+    /**
+     * You can use mvn to run DynamoDBLocalFixture, e.g.
+     * <p>
+     * $ mvn clean package
+     * <p>
+     * $ mvn exec:java -Dexec.mainClass="com.amazonaws.services.dynamodbv2.DynamoDBLocalFixture" \
+     * -Dexec.classpathScope="test" \
+     * -Dsqlite4java.library.path=target/dependencies
+     * <p>
+     * It's recommended to run "aws configure" one time before you run DynamoDBLocalFixture
+     *
+     * @param args - no args
+     * @throws Exception
+     */
     public static void main(String[] args) throws Exception {
         AmazonDynamoDB dynamodb = null;
         try {


### PR DESCRIPTION
Official DynamoDB documentation has a link to DynamoDBLocalFixture code

One of our customer had NPE issue when she tried to run DynamoDBLocalFixture.
Problem was that she did not provide sqlite4java.library.path

Lets add main method comments explaining how to run DynamoDBLocalFixture.
```
mvn exec:java -Dexec.mainClass="com.amazonaws.services.dynamodbv2.DynamoDBLocalFixture" \
-Dexec.classpathScope="test" \
-Dsqlite4java.library.path=target/dependencies
```