### PR TITLE
Add DynamoDBEmbeddedTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <dynamodb-local.endpoint>http://localhost:${dynamodb-local.port}</dynamodb-local.endpoint>
         <aws.java.sdk.version>[1.11.89, 2.0.0)</aws.java.sdk.version>
         <slf4j.version>1.7.5</slf4j.version>
+        <junit.version>4.12</junit.version>
         <aws.dynamodblocal.version>1.11.0.1</aws.dynamodblocal.version>
         <amazon.kinesis-client-library.version>1.7.3</amazon.kinesis-client-library.version>
         <amazon.kinesis-connectors.version>1.3.0</amazon.kinesis-connectors.version>
@@ -42,6 +43,10 @@
             <name>Alexander Patrikalakis</name>
             <email>alexp@amazon.com</email>
             <url>https://www.linkedin.com/in/amcpatrix/en</url>
+        </developer>
+        <developer>
+            <name>Alexander Pivovarov</name>
+            <email>pivovaa@amazon.com</email>
         </developer>
     </developers>
     <inceptionYear>2012</inceptionYear>
@@ -89,6 +94,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -104,6 +115,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.version}</version>
+                <configuration>
+                    <argLine>-Dsqlite4java.library.path=${basedir}/target/dependencies</argLine>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/src/test/java/com/amazonaws/services/dynamodbv2/local/embedded/DynamoDBEmbeddedTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/local/embedded/DynamoDBEmbeddedTest.java
@@ -1,0 +1,85 @@
+/*
+* Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+package com.amazonaws.services.dynamodbv2.local.embedded;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.CreateTableResult;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeyType;
+import com.amazonaws.services.dynamodbv2.model.ListTablesResult;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+
+/**
+ * This class demonstrates how to use DynamoDBEmbedded in JUnit tests
+ *
+ * @author Alexander Pivovarov
+ */
+public class DynamoDBEmbeddedTest {
+
+    @Test
+    public void createTableTest() {
+        AmazonDynamoDB ddb = DynamoDBEmbedded.create().amazonDynamoDB();
+        try {
+            String tableName = "Movies";
+            String hashKeyName = "film_id";
+            CreateTableResult res = createTable(ddb, tableName, hashKeyName);
+
+            TableDescription tableDesc = res.getTableDescription();
+            assertEquals(tableName, tableDesc.getTableName());
+            assertEquals("[{AttributeName: " + hashKeyName + ",KeyType: HASH}]", tableDesc.getKeySchema().toString());
+            assertEquals("[{AttributeName: " + hashKeyName + ",AttributeType: S}]",
+                tableDesc.getAttributeDefinitions().toString());
+            assertEquals(Long.valueOf(1000L), tableDesc.getProvisionedThroughput().getReadCapacityUnits());
+            assertEquals(Long.valueOf(1000L), tableDesc.getProvisionedThroughput().getWriteCapacityUnits());
+            assertEquals("ACTIVE", tableDesc.getTableStatus());
+            assertEquals("arn:aws:dynamodb:ddblocal:000000000000:table/Movies", tableDesc.getTableArn());
+
+            ListTablesResult tables = ddb.listTables();
+            assertEquals(1, tables.getTableNames().size());
+        } finally {
+            ddb.shutdown();
+        }
+    }
+
+    private static CreateTableResult createTable(AmazonDynamoDB ddb, String tableName, String hashKeyName) {
+        List<AttributeDefinition> attributeDefinitions = new ArrayList<AttributeDefinition>();
+        attributeDefinitions.add(new AttributeDefinition(hashKeyName, ScalarAttributeType.S));
+
+        List<KeySchemaElement> ks = new ArrayList<KeySchemaElement>();
+        ks.add(new KeySchemaElement(hashKeyName, KeyType.HASH));
+
+        ProvisionedThroughput provisionedthroughput = new ProvisionedThroughput(1000L, 1000L);
+
+        CreateTableRequest request =
+            new CreateTableRequest()
+                .withTableName(tableName)
+                .withAttributeDefinitions(attributeDefinitions)
+                .withKeySchema(ks)
+                .withProvisionedThroughput(provisionedthroughput);
+
+        return ddb.createTable(request);
+    }
+}


### PR DESCRIPTION
Some users experienced issues when they tried to use DynamoDBEmbedded in JUnit tests.
e.g. https://forums.aws.amazon.com/thread.jspa?threadID=217222&tstart=300

In order to use DynamoDBEmbedded in JUnit test we need to add particular settings to pom.xml to deal with native libraries for SQLLite.

I decided to add DynamoDBEmbeddedTest example and modify pom.xml to make it work.