### PR TITLE
Update DynamoDBLocal version to 1.11.86+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <aws.java.sdk.version>[1.11.89, 2.0.0)</aws.java.sdk.version>
         <slf4j.version>1.7.5</slf4j.version>
         <junit.version>4.12</junit.version>
-        <aws.dynamodblocal.version>1.11.0.1</aws.dynamodblocal.version>
+        <aws.dynamodblocal.version>[1.11.86,2.0)</aws.dynamodblocal.version>
         <amazon.kinesis-client-library.version>1.7.3</amazon.kinesis-client-library.version>
         <amazon.kinesis-connectors.version>1.3.0</amazon.kinesis-connectors.version>
         <dynamodb-streams-kinesis-adapter.version>1.1.1</dynamodb-streams-kinesis-adapter.version>


### PR DESCRIPTION
DynamoDBLocal 1.11.86 is available.
We can use version range [1.11.86-2.0) to automatically upgrade to next 1.11.x version next time.